### PR TITLE
chore(event): update all references for DevFest 2025 event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DevFest 2024
+# DevFest 2025
 Standard Web App for DevFest's Events. <br>
 Show some ❤️ and star the repo to support the project
 
@@ -63,7 +63,7 @@ Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introdu
 Awesome! We would greatly appreciate it if you could contribute to all kinds. To help smoothen the process we have a few non-exhaustive guidelines to follow which should get you going in no time.
 
 ## LICENSE
-Check out the developer [LICENSE](https://github.com/oss-labs/devfest-2024/blob/main/LICENSE)
+Check out the developer [LICENSE](https://github.com/oss-labs/devfest-2025/blob/main/LICENSE)
 
 ## Facing Any Problem or need any Help?
-Write us in the [issues](https://github.com/oss-labs/devfest-2024/issues) section. Our team will try to solve your issue within 10-12 hours.<be>
+Write us in the [issues](https://github.com/oss-labs/devfest-2025/issues) section. Our team will try to solve your issue within 10-12 hours.<be>

--- a/components/core/AppToolbar.vue
+++ b/components/core/AppToolbar.vue
@@ -51,24 +51,18 @@
 		<ClientOnly>
 			<v-btn
 				rounded
-				v-if="
-					mainData &&
-					mainData.eventInfo.registeration.link.length &&
-					new Date(mainData.eventInfo.registeration.end_date) >
-						new Date()
-				"
-				:href="mainData.eventInfo.registeration.link"
+				disabled
 				class="d-md-flex d-lg-flex d-sm-flex d-none mr-3"
 				target="_blank"
-				color="#FFD427"
+				color="#6c757d"
 				style="
 					border: 1.5px solid #1e1e1e;
-					color: black;
+					color: white;
 					text-transform: capitalize;
 					font-weight: 100;
 				"
 				variant="flat"
-				>Get Your Tickets</v-btn
+				>Coming Soon</v-btn
 			>
 		</ClientOnly>
 	</v-app-bar>

--- a/components/home/HeroSection.vue
+++ b/components/home/HeroSection.vue
@@ -4,7 +4,7 @@
 			<v-col md="6" sm="6" cols="12">
 				<h1 class="responsive-h1 my-4">
 					DevFest <br />
-					{{ mainData.communityLocation.city }} 2024
+					{{ mainData.communityLocation.city }} 2025
 				</h1>
 				<p class="" :style="{ maxWidth: '90%' }">
 					{{ mainData.eventInfo.description.short }}
@@ -31,19 +31,14 @@
 				<v-btn
 					rounded
 					size="large"
-					color="#FFD427"
-					v-if="
-						mainData.eventInfo &&
-						mainData.eventInfo.registeration.link.length &&
-						new Date(mainData.eventInfo.registeration.end_date) >
-							new Date()
-					"
-					:href="mainData.eventInfo.registeration.link"
+					color="#6c757d"
+					disabled
+					
 					class="my-4 mt-3"
 					target="_blank"
-					style="border: 1.5px solid #1e1e1e; color: black"
+					style="border: 1.5px solid #1e1e1e; color: white"
 					variant="flat"
-					>Get Your Tickets</v-btn
+					>Coming Soon</v-btn
 				>
 			</v-col>
 			<v-col md="6" sm="6" cols="12">

--- a/data/config.json
+++ b/data/config.json
@@ -13,43 +13,43 @@
     "youtube": "https://www.youtube.com/@gdgprayagraj"
   },
   "eventInfo": {
-    "name": "DevFest Prayagraj 2024",
-    "date": "Oct 26, 2024",
+    "name": "DevFest Prayagraj 2025",
+    "date": "29 November 2025",
     "time": "9 AM - 5 PM IST",
     "venue": {
       "address": "UIT, Prayagraj",
       "map_link": "https://maps.app.goo.gl/GNhyNf9GW4S75vQK9"
     },
     "registeration": {
-      "link": "https://konfhub.com/dfprayagraj24",
-      "end_date": "2024-10-25"
+      "link": "#",
+      "end_date": "2025-10-20"
     },
     "description": {
-      "short": "Experience DevFest Prayagraj 2024 - where innovation meets the rich heritage of Prayagraj. Join us as we blend cutting-edge technology with local culture, bringing the spirit of collaboration, knowledge, and growth to the heart of the Sangam city. Let's build the future of AI, rooted in values and driven by purpose.",
-      "long": "Experience DevFest Prayagraj 2024 - where innovation meets the rich heritage of Prayagraj. Join us as we blend cutting-edge technology with local culture, bringing the spirit of collaboration, knowledge, and growth to the heart of the Sangam city. Let's build the future of AI, rooted in values and driven by purpose."
+      "short": "Experience DevFest Prayagraj 2025 - where innovation meets the rich heritage of Prayagraj. Join us as we blend cutting-edge technology with local culture, bringing the spirit of collaboration, knowledge, and growth to the heart of the Sangam city. Let's build the future of technology, rooted in values and driven by purpose.",
+      "long": "Experience DevFest Prayagraj 2025 - where innovation meets the rich heritage of Prayagraj. Join us as we blend cutting-edge technology with local culture, bringing the spirit of collaboration, knowledge, and growth to the heart of the Sangam city. Let's build the future of technology, rooted in values and driven by purpose."
     },
     "stats": [
       {
         "name": "Speakers",
-        "value": "7+",
+        "value": "10+",
         "color": "#C3ECF6",
         "image": "img/common/blue.png"
       },
       {
         "name": "Participants",
-        "value": "500+",
+        "value": "700+",
         "color": "#F8D8D8",
         "image": "img/common/pink.png"
       },
       {
         "name": "Sessions",
-        "value": "7+",
+        "value": "12+",
         "color": "#CCF6C5",
         "image": "img/common/green.png"
       },
       {
         "name": "Workshops",
-        "value": "2+",
+        "value": "10+",
         "color": "#FFE7A5",
         "image": "img/common/yellow.png"
       }
@@ -74,7 +74,7 @@
       "stats": [
         {
           "name": "Speakers",
-          "value": "5+"
+          "value": "7+"
         },
         {
           "name": "Participants",
@@ -92,7 +92,7 @@
     }
   },
   "seo": {
-    "keywords": "GDG, DevFest, Google, DevFest, GDG Prayagraj, GDG Prayagraj DevFest, GDG Prayagraj DevFest 2024",
+    "keywords": "GDG, DevFest, Google, DevFest, GDG Prayagraj, GDG Prayagraj DevFest, GDG Prayagraj DevFest 2025",
     "hostUrl": "https://devfest.gdgprayagraj.com"
   }
 }

--- a/data/faq.json
+++ b/data/faq.json
@@ -9,7 +9,7 @@
     },
     {
         "question": "When and where is the event taking place?",
-        "answer": "Date: 26th Oct 2024<br>Venue: UIT(United Institute of Technology) Auditorium, Prayagraj<br>Time: 9AM to 5PM"
+        "answer": "Date: 29th Nov 2025<br>Venue: UIT(United Institute of Technology) Auditorium, Prayagraj<br>Time: 9AM to 5PM"
     },
     {
         "question": "Will the accommodation facility be provided to attendees?",

--- a/data/schedule.json
+++ b/data/schedule.json
@@ -1,7 +1,7 @@
 [
     {
         "day": "1",
-        "date": "Oct 26 (Hall 1)",
+        "date": "Oct 25 (Hall 1)",
         "schedule": [
             {
                 "startTime": "9:00 AM",

--- a/data/sessions.json
+++ b/data/sessions.json
@@ -8,7 +8,7 @@
         "link": "/img/past-devfest/image-3.png",
         "time": "9:00 AM to 9:30 AM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             108
@@ -23,7 +23,7 @@
         "link": "/img/speaker-poster/Nishant-welpulwar.png",
         "time": "10:30 AM to 11:00 AM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             101
@@ -38,7 +38,7 @@
         "link": "/img/speaker-poster/Vivek-Kumar.png",
         "time": "11:00 AM to 11:30 AM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             105
@@ -53,7 +53,7 @@
         "link": "/img/speaker-poster/Anubhav-Singh.png",
         "time": "11:30 AM to 12:00 PM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             106
@@ -68,7 +68,7 @@
         "link": "/img/speaker-poster/food.jpg",
         "time": "12:00 PM to 1:00 PM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": []
     },
@@ -81,7 +81,7 @@
         "link": "/img/speaker-poster/Praveen-Das.png",
         "time": "1:00 PM to 1:30 PM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             109
@@ -96,7 +96,7 @@
         "link": "/img/speaker-poster/Dhrumil-Shah.png",
         "time": "1:30 PM to 2:00 PM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             102
@@ -111,7 +111,7 @@
         "link": "",
         "time": "",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "",
         "speakers": []
     },
@@ -124,7 +124,7 @@
         "link": "/img/past-devfest/image-1.png",
         "time": "3:30 PM to 4:00 PM (IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": []
     },
@@ -137,7 +137,7 @@
         "link": "",
         "time": "4:00 PM(IST)",
         "format": "Day 1",
-        "date": "Oct 26, 2024",
+        "date": "Oct 25, 2025",
         "timeDuration": "30",
         "speakers": [
             108

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -14,7 +14,7 @@
         "sponsors": [
             {
                 "name": "TensorFlow User Group (TFUG), Prayagraj",
-                "link": "https://www.meetup.comtensorflow-user-group-prayagraj",
+                "link": "https://www.meetup.com/tensorflow-user-group-prayagraj",
                 "logo": "tfugprayagraj.png"
             },
             {

--- a/pages/coc.vue
+++ b/pages/coc.vue
@@ -5,7 +5,7 @@
         <v-col md="12">
           <h1>Code of Conduct</h1>
           <p>
-            All participants of DevFest 2024 event, online attendees, event
+            All participants of DevFest 2025 event, online attendees, event
             staff, and speakers, must abide by the following policy:
           </p>
 


### PR DESCRIPTION
- Change event year from 2024 to 2025 in README, HeroSection, config, FAQ, and sessions
- Update event date to November 29, 2025 and adjust related schedule dates
- Disable ticket buttons and update their labels to "Coming Soon"
- Update registration link to placeholder and registration end date to 2025-10-20
- Increase stats numbers for speakers, participants, sessions, and workshops
- Fix sponsor meetup link URL format
- Update Code of Conduct to reference DevFest 2025 event